### PR TITLE
make decoding optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 *.pyc
+
+fixspecs/FIX40.xml
+
+*.xml
+
+.cache/v/cache/lastfailed
+
+.idea/.name
+
+.idea/pyfixmsg.iml

--- a/pyfixmsg/__init__.py
+++ b/pyfixmsg/__init__.py
@@ -6,6 +6,7 @@ import itertools
 
 if sys.version_info.major >= 3:
     STRSUM = sum
+    unicode = str
 else:
     STRSUM = lambda x: sum(bytearray(x))
 
@@ -120,7 +121,13 @@ def len_and_chsum(msg):
     count = 0
     chsum_count = 0
     for tag, value in list(msg.items()):
-        tag, value = str(tag).encode('ascii'), str(value).encode('UTF-8')
+        if not isinstance(tag, bytes):
+           tag = str(tag).encode('ascii')
+        if not isinstance(value, bytes):
+            if isinstance(value, unicode):
+                value = value.encode('UTF-8')
+            else:
+                value = str(value).encode('UTF-8')
         if tag == b'8':
             chsum_count += STRSUM(tag)
             chsum_count += STRSUM(value)

--- a/pyfixmsg/reference.py
+++ b/pyfixmsg/reference.py
@@ -160,7 +160,12 @@ class FixSpec(object):
         self._eager = eager
         self.tags = None
         self._populate_tags()
-        self.msg_types = {m.msgtype: m for m in (MessageType(e, self) for e in self.tree.findall('messages/message'))}
+        self.msg_types = {m.msgtype.encode('ascii'): m for m in
+                         (MessageType(e, self) for e in self.tree.findall('messages/message'))}
+        # We need to be able to look msg type for both decoded and raw values of tag 35
+        # this is effectively noop on python 2.7
+        self.msg_types.update({m.msgtype: m for m in
+                          (MessageType(e, self) for e in self.tree.findall('messages/message'))})
         self.header_tags = [self.tags.by_name(t.get('name')) for t in self.tree.findall('header/field')]
         self.tree = None
 

--- a/pyfixmsg/util.py
+++ b/pyfixmsg/util.py
@@ -1,16 +1,25 @@
 """Small utility-type functions"""
 
+import sys
 import datetime
 
 DATEFORMAT = '%Y%m%d-%H:%M:%S.%f'
 
+if sys.version_info.major >= 3:
+    unicode = str
 
-def int_or_str(val):
+def int_or_str(val, encoding=None):
     """ simple format to int or string if not possible """
     try:
         return int(val)
     except ValueError:
-        return str(val).strip()
+        if encoding is None:
+            if isinstance(val, bytes):
+               return val
+            return str(val)
+        elif isinstance(val, bytes):
+           return val.decode(encoding).strip()
+
 
 
 def utc_timestamp():


### PR DESCRIPTION
The default behaviour was to decode all values to unicode strings. That
is not mandated by the spec and can be confusing for the end-user.
Added two arguments to Codec’s constructor to control this. Also added
testcases for these.