### PR TITLE
Ensure FIX message header and trailer tags are also used for tag ordering

### DIFF
--- a/pyfixmsg/reference.py
+++ b/pyfixmsg/reference.py
@@ -166,6 +166,7 @@ class FixSpec(object):
         # this is effectively noop on python 2.7
         self.msg_types.update({m.msgtype: m for m in
                           (MessageType(e, self) for e in self.tree.findall('messages/message'))})
+        self.header_tags = [self.tags.by_name(t.get('name')) for t in self.tree.findall('header/field')]
         self.tree = None
 
     def _populate_tags(self):


### PR DESCRIPTION
Thanks for making pyfixmsg open source.

While experimenting with Testplan I encountered a problem with tag ordering during FIX logon message exchange.
Our application fails to parse the logon response message from pyfixmsg fixserver (we use OnixS C++ FIX engine), our log:
```
Garbled message received. Mandatory session tags 8, 9, 35 and 10 are missed or out of order. Field [tag=8]. Message [type=N/A, seqNum=N/A, dictionary=ThomsonReutersTrading].
```
The debug output in fixserver.log does show the 35=A logon response message but without standard header ordering applied:
```
DEBUG Sending on connection (b'REUTERS_SellSide', b'REUTERS_BuySide') message b'35=A;98=0;108=4;141=N;789=1;553=USRC;554=T3TUDOR1;1137=9;8=FIXT.1.1;9=169;34=1;49=REUTERS_SellSide;52=20190115-10:06:59.797535;56=REUTERS_BuySide;57=FXM;142=TRFXMUS12345;1128=9;1407=100;10=019;'
```

With the patch of this pull request applied it works for us, our log:
```
Sent: '8=FIXT.1.1|9=166|35=A|49=REUTERS_BuySide|56=REUTERS_SellSide|34=1|142=TRFXMUS12345|57=FXM|52=20190115-10:24:19.085|1128=9|98=0|108=4|141=N|789=1|553=USRC|554=T3TUDOR1|1137=9|1407=100|10=101|'
Incoming: '8=FIXT.1.1|9=169|35=A|49=REUTERS_SellSide|56=REUTERS_BuySide|34=1|142=TRFXMUS12345|57=FXM|52=20190115-10:24:19.085933|1128=9|98=0|108=4|141=N|789=1|553=USRC|554=T3TUDOR1|1137=9|1407=100|10=007|'
```
Debug output in fixserver.log:
```
DEBUG Sending on connection (b'REUTERS_SellSide', b'REUTERS_BuySide') message b'8=FIXT.1.1;9=169;35=A;49=REUTERS_SellSide;56=REUTERS_BuySide;34=1;142=TRFXMUS12345;57=FXM;52=20190115-10:24:19.085933;1128=9;98=0;108=4;141=N;789=1;553=USRC;554=T3TUDOR1;1137=9;1407=100;10=007;'
DEBUG Received from connection (None, None) msg b'8=FIXT.1.1;9=149;35=1;49=REUTERS_BuySide;56=REUTERS_SellSide;34=2;50=REUTERS_GWY;142=TRFXMUS12345;57=FXM;52=20190115-10:24:19.086;1128=9;112=20190115-10:24:19.086572;10=225;'
DEBUG Sending on connection (b'REUTERS_SellSide', b'REUTERS_BuySide') message b'8=FIXT.1.1;9=106;35=0;49=REUTERS_SellSide;56=REUTERS_BuySide;34=2;52=20190115-10:24:19.341908;112=20190115-10:24:19.086572;10=108;'
```

Could be I missed some config or option somewhere, but hope this patch is useful if I did not. (Sorry I did not have time to write a unit test).