### PR TITLE
fix tag ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ fixspecs/FIX40.xml
 .idea/.name
 
 .idea/pyfixmsg.iml
+
+venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ fixspecs/FIX40.xml
 
 .idea/pyfixmsg.iml
 
-venv/*

--- a/pyfixmsg/reference.py
+++ b/pyfixmsg/reference.py
@@ -175,7 +175,7 @@ class FixSpec(object):
         # this is effectively noop on python 2.7
         self.msg_types.update({m.msgtype: m for m in
                                (MessageType(e, self) for e in self.tree.findall('messages/message'))})
-        self.header_tags = [self.tags.by_name(t.get('name')).tag for t in self.tree.findall('header/field')]
+        self.header_tags = [self.tags.by_name(t.get('name')) for t in self.tree.findall('header/field')]
         self.tree = None
 
     def _populate_tags(self):
@@ -333,7 +333,10 @@ def _extract_sorting_key(definition, spec, sorting_key=None, index=0):
         sorting_key = {35: -1, 10: int(10e9)}
         header_tags = spec.header_tags or HEADER_TAGS
         for index, item in enumerate(header_tags):
-            sorting_key[item] = index
+            if isinstance(item, FixTag):
+                sorting_key[item.tag] = index
+            else:
+                sorting_key[item] = index
     start_index = index + 1
     for index, (item, _) in enumerate(definition):
         if isinstance(item, FixTag):

--- a/pyfixmsg/reference.py
+++ b/pyfixmsg/reference.py
@@ -175,7 +175,7 @@ class FixSpec(object):
         # this is effectively noop on python 2.7
         self.msg_types.update({m.msgtype: m for m in
                                (MessageType(e, self) for e in self.tree.findall('messages/message'))})
-        self.header_tags = [self.tags.by_name(t.get('name')) for t in self.tree.findall('header/field')]
+        self.header_tags = [self.tags.by_name(t.get('name')).tag for t in self.tree.findall('header/field')]
         self.tree = None
 
     def _populate_tags(self):

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -235,6 +235,9 @@ class TestReference(object):
         assert serialised == codec.serialise(msg)
 
     def test_nested_rgroup(self, spec):
+        if 'FIX.4.4' not in spec.version and 'FIX5.' not in spec.version:
+            # only relevant for fix 4.4 or above
+            return
         codec = Codec(spec=spec, decode_as='UTF-8')
         msg = b'35=AE;555=1;687=AA;683=2;688=1;689=1;' \
               b'688=2;689=2;17807=11;10=000;'
@@ -271,6 +274,9 @@ class TestReference(object):
         assert serialised == codec.serialise(msg)
 
     def test_empty_rgroups(self, spec):
+        if 'FIX.4.4' not in spec.version and 'FIX5.' not in spec.version:
+            # only relevant for fix 4.4 or above
+            return
         codec = Codec(spec=spec, decode_as='UTF-8')
         msg = b'35=AJ;17807=11;232=2;233=bli;234=blu;' \
               b'233=blih;234=bluh;555=0;10=000;'
@@ -650,3 +656,12 @@ class TestOperators(object):
         with pytest.raises(KeyError):
             after[270]
         assert list(after.find_all(270)) == [[268, 0, 270], [268, 1, 270]]
+
+    def test_serialisation_header(self, spec):
+        if 'FIX5' in spec.version:
+            msg = self.FixMessage()
+            msg.codec = Codec(spec=spec)
+            msg.load_fix(b'8=FIX.4.2;9=97;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=000;')
+            assert msg.output_fix() == b'8=FIX.4.2;9=43;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=236;'
+            msg = self.FixMessage({56:'B', 34:12, 10:100, 9:4, 35:8, 8:'FIX4.4'})
+            assert msg.output_fix() == b'8=FIX4.4;9=16;35=8;56=B;34=12;10=162;'

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -270,6 +270,35 @@ class TestReference(object):
                      '688=2;689=2;17807=11;10=000;'.replace(';', chr(1)).encode('UTF-8')
         assert serialised == codec.serialise(msg)
 
+    def test_empty_rgroups(self, spec):
+        codec = Codec(spec=spec, decode_as='UTF-8')
+        msg = b'35=AJ;17807=11;232=2;233=bli;234=blu;' \
+              b'233=blih;234=bluh;555=0;10=000;'
+        msg = codec.parse(msg, separator=';')
+        assert {35: 'AJ',
+                17807: '11',
+                232: [
+                    {233: 'bli', 234: 'blu'},
+                    {233: 'blih', 234: 'bluh'}
+                ],
+                555: [],
+                10: '000'
+                } == msg
+        lhs = tuple(codec._unmap(msg))
+        assert lhs == ((35, 'AJ'),
+                       (232, 2),
+                       (233, 'bli'),
+                       (234, 'blu'),
+                       (233, 'blih'),
+                       (234, 'bluh'),
+                       (555, 0),
+                       (17807, '11'),
+                       (10, '000')
+                       )
+        serialised = '35=AJ;232=2;233=bli;234=blu;233=blih;234=bluh;555=0;' \
+                     '17807=11;10=000;'.replace(';', chr(1)).encode('UTF-8')
+        assert serialised == codec.serialise(msg)
+
     def test_large_msg(self, spec, profiler):
         setup = """
 import pyfixmsg.reference as ref

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -594,6 +594,7 @@ class TestOperators(object):
         assert b'D' == msg[35]
         assert b'3' == msg[34]
         assert b'154' == msg[10]
+        assert msg.get_raw_message() == buff
 
     def test_pickling(self):
         a = self.FixMessage()

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -658,10 +658,9 @@ class TestOperators(object):
         assert list(after.find_all(270)) == [[268, 0, 270], [268, 1, 270]]
 
     def test_serialisation_header(self, spec):
-        if 'FIX5' in spec.version:
-            msg = self.FixMessage()
-            msg.codec = Codec(spec=spec)
-            msg.load_fix(b'8=FIX.4.2;9=97;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=000;')
-            assert msg.output_fix() == b'8=FIX.4.2;9=43;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=236;'
-            msg = self.FixMessage({56:'B', 34:12, 10:100, 9:4, 35:8, 8:'FIX4.4'})
-            assert msg.output_fix() == b'8=FIX4.4;9=16;35=8;56=B;34=12;10=162;'
+        msg = self.FixMessage()
+        msg.codec = Codec(spec=spec)
+        msg.load_fix(b'8=FIX.4.2;9=97;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=000;')
+        assert msg.output_fix() == b'8=FIX.4.2;9=43;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=236;'
+        msg = self.FixMessage({56:'B', 34:12, 10:100, 9:4, 35:8, 8:'FIX4.4'})
+        assert msg.output_fix() == b'8=FIX4.4;9=16;35=8;56=B;34=12;10=162;'

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -20,7 +20,7 @@ from pyfixmsg import RepeatingGroup, len_and_chsum
 SPEC = None
 
 if sys.version_info.major >= 3:
-  unicode = str
+    unicode = str
 
 
 @pytest.fixture
@@ -216,22 +216,22 @@ class TestReference(object):
         msg = b'35=B;215=1;216=1;' \
               b'146=2;55=EURUSD;55=EURGBP;10=000;'
         msg = codec.parse(msg, separator=';')
-        assert {35: 'B', 
-                215: [{216 : '1'}], 
+        assert {35: 'B',
+                215: [{216 : '1'}],
                 146: [{55 : 'EURUSD'}, {55 : 'EURGBP'}],
                 10: '000'
                 } == msg
         lhs = tuple(codec._unmap(msg))
         assert lhs == ((35, 'B'),
+                       (215, 1),
+                       (216, '1'),
                        (146, 2),
                        (55, 'EURUSD'),
                        (55, 'EURGBP'),
-                       (215, 1),
-                       (216, '1'),
                        (10, '000')
                        )
-        serialised = '35=B;146=2;55=EURUSD;55=EURGBP;' \
-                     '215=1;216=1;10=000;'.replace(';', chr(1)).encode('UTF-8')
+        serialised = '35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;' \
+                     '10=000;'.replace(';', chr(1)).encode('UTF-8')
         assert serialised == codec.serialise(msg)
 
     def test_nested_rgroup(self, spec):
@@ -257,46 +257,17 @@ class TestReference(object):
         lhs = tuple(codec._unmap(msg))
         assert lhs == ((35, 'AE'),
                        (555, 1),
+                       (687, 'AA'),
                        (683, 2),
                        (688, '1'),
                        (689, '1'),
                        (688, '2'),
                        (689, '2'),
-                       (687, 'AA'),
                        (17807, '11'),
                        (10, '000')
                        )
-        serialised = '35=AE;555=1;683=2;688=1;689=1;' \
-                     '688=2;689=2;687=AA;17807=11;10=000;'.replace(';', chr(1)).encode('UTF-8')
-        assert serialised == codec.serialise(msg)
-
-    def test_empty_rgroups(self, spec):
-        codec = Codec(spec=spec, decode_as='UTF-8')
-        msg = b'35=AJ;17807=11;232=2;233=bli;234=blu;' \
-              b'233=blih;234=bluh;555=0;10=000;'
-        msg = codec.parse(msg, separator=';')
-        assert {35: 'AJ',
-                17807: '11',
-                232: [
-                    {233: 'bli', 234: 'blu'},
-                    {233: 'blih', 234: 'bluh'}
-                ],
-                555: [],
-                10: '000'
-                } == msg
-        lhs = tuple(codec._unmap(msg))
-        assert lhs == ((35, 'AJ'),
-                       (232, 2),
-                       (233, 'bli'),
-                       (234, 'blu'),
-                       (233, 'blih'),
-                       (234, 'bluh'),
-                       (555, 0),
-                       (17807, '11'),
-                       (10, '000')
-                       )
-        serialised = '35=AJ;232=2;233=bli;234=blu;233=blih;234=bluh;' \
-                     '555=0;17807=11;10=000;'.replace(';', chr(1)).encode('UTF-8')
+        serialised = '35=AE;555=1;687=AA;683=2;688=1;689=1;' \
+                     '688=2;689=2;17807=11;10=000;'.replace(';', chr(1)).encode('UTF-8')
         assert serialised == codec.serialise(msg)
 
     def test_large_msg(self, spec, profiler):
@@ -594,7 +565,6 @@ class TestOperators(object):
         assert b'D' == msg[35]
         assert b'3' == msg[34]
         assert b'154' == msg[10]
-        assert msg.get_raw_message() == buff
 
     def test_pickling(self):
         a = self.FixMessage()


### PR DESCRIPTION
fix the tag ordering issue when using FIX44's spec. 
This contains a few formatting/typos fixes in addition to the bug fix changes, let me know if you want me to split these changes out. The test changes pass against the FIX44.xml reference. I'll look at running the tests automatically against multiple specs.