### PR TITLE
Maintenance for pyfixmsg

### DIFF
--- a/pyfixmsg/codecs/stringfix.py
+++ b/pyfixmsg/codecs/stringfix.py
@@ -124,6 +124,7 @@ class Codec(object):
         else:
             tagvals = ((int_or_str(tval[0]), tval[1]) for tval in tagvals)
         # Need to add logic to parse Encoded* tags according to 347
+
         if self._no_groups or self.spec is None or msg_type is None:
             # no groups can be found without a spec, so no point looking up the msg type.
             return self._frg_class(tagvals)
@@ -138,8 +139,8 @@ class Codec(object):
                     msg[tag] = RepeatingGroup.create_repeating_group(tag)
                 else:
                     contents, last_tagval = self._process_group(tag, tagvals,
-                                                               msg_type=msg_type,
-                                                               group=groups[tag])
+                                                                msg_type=msg_type,
+                                                                group=groups[tag])
                     msg[tag] = contents
                     if last_tagval:
                         tagvals.send(last_tagval)
@@ -208,7 +209,7 @@ class Codec(object):
         def sort_values(msg, spec):
             """ Sort {tag:value} map into an iterable  """
             tvals = list(msg.items())
-            get_sorting_key = lambda x: spec.sorting_key.get(x[0], int(10e8 + x[0]))
+            get_sorting_key = lambda x: spec.sorting_key.get(x[0], int(1e9 + x[0]))
             tvals.sort(key=get_sorting_key)
             #  using a deque for this already-sorted data structure yields a ~10% speed improvement on serialisation
             expanded = deque()
@@ -225,7 +226,7 @@ class Codec(object):
         if self.spec is None:
             #  No spec, let's just get reasonable header order, and 10 at the end.
             tag_vals = list(msg.items())
-            tag_vals.sort(key=lambda x: HEADER_SORT_MAP.get(x[0], int(10e8 + x[0])))
+            tag_vals.sort(key=lambda x: HEADER_SORT_MAP.get(x[0], int(1e9 + x[0])))
             return tag_vals
         else:
             return sort_values(msg, self.spec.msg_types[msg[35]])
@@ -238,7 +239,8 @@ class Codec(object):
         :type msg: ``dict``-like interface
         :param delimiter: as in ``parse()``
         :param separator: as in ``parse()``
-        :param encoding: as in ``parse()``
+        :param encoding: encoding mode
+        :type encoding: ``str``
         """
         tag_vals = self._unmap(msg)
         output = deque()

--- a/pyfixmsg/fixmessage.py
+++ b/pyfixmsg/fixmessage.py
@@ -226,7 +226,7 @@ class FixMessage(FixFragment):  # pylint: disable=R0904
         """
         copy module support. This copies the message by serialising it and parsing the serialised
         data back into a new message. This is a lot faster than deepcopy or other techniques.
-         """
+        """
         new_msg = self.__class__()
         new_msg.codec = self.codec
         new_msg.from_wire(self.to_wire())
@@ -287,7 +287,6 @@ class FixMessage(FixFragment):  # pylint: disable=R0904
         """
         Sets the tag if value is neither None or the empty string. Deletes the tag otherwise.
         Only works on top-level tags (not inside repeating groups)
-
         """
         if value is not None and value != "":  # don't remove if the tag is 0
             self[tag] = value

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -657,10 +657,10 @@ class TestOperators(object):
             after[270]
         assert list(after.find_all(270)) == [[268, 0, 270], [268, 1, 270]]
 
-    def test_serialisation_header(self, spec):
+    def test_serialisation_header_and_trailer(self, spec):
         msg = self.FixMessage()
         msg.codec = Codec(spec=spec)
-        msg.load_fix(b'8=FIX.4.2;9=97;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=000;')
-        assert msg.output_fix() == b'8=FIX.4.2;9=43;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;10=236;'
-        msg = self.FixMessage({56:'B', 34:12, 10:100, 9:4, 35:8, 8:'FIX4.4'})
-        assert msg.output_fix() == b'8=FIX4.4;9=16;35=8;56=B;34=12;10=162;'
+        msg.load_fix(b'8=FIX.4.2;9=97;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;89=SIGSTR;93=6;10=000;')
+        assert msg.output_fix() == b'8=FIX.4.2;9=58;35=B;215=1;216=1;146=2;55=EURUSD;55=EURGBP;93=6;89=SIGSTR;10=093;'
+        msg = self.FixMessage({89:'SIGSTR', 93:6, 56:'B', 34:12, 10:100, 9:4, 35:8, 8:'FIX4.4'})
+        assert msg.output_fix() == b'8=FIX4.4;9=31;35=8;56=B;34=12;93=6;89=SIGSTR;10=010;'


### PR DESCRIPTION
* Support tag ordering for trailer tags.

* Add header tags 1128 & 1129 defined in Fix spec 5.0.

* Make complete the doc strings for some arguments.

* Refine code format.